### PR TITLE
fix: map DuckDB TIMESTAMP_S/_MS/_NS to Keboola TIMESTAMP (SUPPORT-16781)

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -159,9 +159,7 @@ class Component(ComponentBase):
             try:
                 # Get table schema
                 table_meta = self._connection.execute(f"DESCRIBE TABLE '{table.source}';").fetchall()
-                schema = {
-                    c[0]: ColumnDefinition(data_types=self.duckdb_type_to_base_type(c[1])) for c in table_meta
-                }
+                schema = {c[0]: ColumnDefinition(data_types=self.duckdb_type_to_base_type(c[1])) for c in table_meta}
                 # Create output table definition
                 out_table = self.create_out_table_definition(
                     name=table.source,
@@ -195,9 +193,7 @@ class Component(ComponentBase):
 
     # DuckDB base-type names whose parenthesized modifier is a meaningful length /
     # precision-scale (as opposed to complex types like STRUCT(...) that also use parentheses).
-    _LENGTH_BEARING_TYPES = frozenset(
-        {"DECIMAL", "NUMERIC", "VARCHAR", "CHAR", "BPCHAR", "STRING", "TEXT"}
-    )
+    _LENGTH_BEARING_TYPES = frozenset({"DECIMAL", "NUMERIC", "VARCHAR", "CHAR", "BPCHAR", "STRING", "TEXT"})
 
     @staticmethod
     def _map_base_type(dtype: str) -> SupportedDataTypes:
@@ -221,7 +217,16 @@ class Component(ComponentBase):
             return SupportedDataTypes.FLOAT
         elif dtype == "BOOLEAN":
             return SupportedDataTypes.BOOLEAN
-        elif dtype in ["TIMESTAMP", "TIMESTAMP WITH TIME ZONE"]:
+        elif dtype in [
+            "TIMESTAMP",
+            "TIMESTAMP WITH TIME ZONE",
+            "TIMESTAMP_S",
+            "TIMESTAMP_MS",
+            "TIMESTAMP_NS",
+        ]:
+            # DuckDB exposes sub-second precision as distinct named types
+            # (TIMESTAMP_S/_MS/_NS) rather than a TIMESTAMP(p) modifier. They all
+            # map to Keboola TIMESTAMP; without these they fell through to STRING.
             return SupportedDataTypes.TIMESTAMP
         elif dtype == "DATE":
             return SupportedDataTypes.DATE

--- a/tests/unit/test_component_types.py
+++ b/tests/unit/test_component_types.py
@@ -49,6 +49,13 @@ class TestDuckdbTypeToBaseType(unittest.TestCase):
         self._assert("TIMESTAMP", SupportedDataTypes.TIMESTAMP, None)
         self._assert("TIMESTAMP WITH TIME ZONE", SupportedDataTypes.TIMESTAMP, None)
 
+    def test_timestamp_precision_variants(self):
+        # The customer's case: TIMESTAMP_S came out as VARCHAR(16777216) because the
+        # sub-second precision variants were not recognized and fell back to STRING.
+        self._assert("TIMESTAMP_S", SupportedDataTypes.TIMESTAMP, None)
+        self._assert("TIMESTAMP_MS", SupportedDataTypes.TIMESTAMP, None)
+        self._assert("TIMESTAMP_NS", SupportedDataTypes.TIMESTAMP, None)
+
     def test_complex_type_falls_back_to_string_without_length(self):
         # STRUCT(...) / arrays must not leak their inner definition into `length`.
         self._assert("STRUCT(a INTEGER)", SupportedDataTypes.STRING, None)


### PR DESCRIPTION
## Why

Follow-up to #19 (the DECIMAL precision fix) on the same support ticket. On retest the customer found that a column cast as `TIMESTAMP_S` came out in Storage as `VARCHAR(16777216)` — not a timestamp type at all. The precision fix addressed the specific reported case rather than the timestamp mapping as a whole.

Root cause: DuckDB exposes sub-second timestamp precision as **distinct named types** (`TIMESTAMP_S`, `TIMESTAMP_MS`, `TIMESTAMP_NS`), not as a `TIMESTAMP(p)` modifier, so `DESCRIBE` returns those names verbatim. `_map_base_type` only matched `TIMESTAMP` and `TIMESTAMP WITH TIME ZONE`, so the variants fell through to the `else` branch and were mapped to `STRING`.

Verified against DuckDB 1.5.2 that `DESCRIBE` emits exactly `TIMESTAMP_S` / `TIMESTAMP_MS` / `TIMESTAMP_NS`, and that `TIMESTAMPTZ` is already covered (it reports as `TIMESTAMP WITH TIME ZONE`).

## What

- Add `TIMESTAMP_S` / `_MS` / `_NS` to the `TIMESTAMP` branch of `_map_base_type` so all four map to Keboola `TIMESTAMP`.
- Add a unit test locking the three variants.

Scope note: DuckDB types with no Keboola base-type equivalent (`TIME`, `INTERVAL`, `UUID`, `BLOB`, `JSON`, …) legitimately remain `STRING` — Keboola base types are only INTEGER / NUMERIC / FLOAT / BOOLEAN / DATE / TIMESTAMP / STRING.

## Testing

- `uv run ruff check .` — clean
- `uv run python -m pytest tests/unit` — 39 passed
- Functional/datadir suite is Docker-only (needs the `duckdb-1.4.4` / `duckdb-1.5.2` version venvs); runs in CI.

## Not covered here

The other open item on the ticket — preserving `VARCHAR(n)` length — is a separate, larger piece of work (DuckDB drops the length before export, so it would require parsing the SQL cast text with SQLGlot) and needs a product decision. Not in scope for this PR.