### PR TITLE
fix: map DuckDB TIMESTAMP_S/_MS/_NS to correct precision (SUPPORT-16781)

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -195,6 +195,16 @@ class Component(ComponentBase):
     # precision-scale (as opposed to complex types like STRUCT(...) that also use parentheses).
     _LENGTH_BEARING_TYPES = frozenset({"DECIMAL", "NUMERIC", "VARCHAR", "CHAR", "BPCHAR", "STRING", "TEXT"})
 
+    # DuckDB encodes sub-second timestamp precision in the type NAME, not a TIMESTAMP(p)
+    # modifier, so the fractional-seconds precision can't be parsed from parentheses like
+    # DECIMAL(p,s) — it has to be looked up from the name. Map each variant to the Keboola
+    # TIMESTAMP length (= fractional-seconds precision) so Storage creates TIMESTAMP_NTZ(p)
+    # instead of defaulting to (9): TIMESTAMP_S = second, _MS = millisecond, _NS = nanosecond.
+    # Plain TIMESTAMP (microsecond) and TIMESTAMP WITH TIME ZONE are deliberately left with no
+    # explicit length (Storage default) — the common case is unchanged to keep the blast radius
+    # off existing configs; only the explicit precision variants get a tightened width.
+    _TIMESTAMP_PRECISION = {"TIMESTAMP_S": "0", "TIMESTAMP_MS": "3", "TIMESTAMP_NS": "9"}
+
     @staticmethod
     def _map_base_type(dtype: str) -> SupportedDataTypes:
         """Map a DuckDB base type name (without any length/precision modifier) to a Keboola type."""
@@ -244,6 +254,11 @@ class Component(ComponentBase):
         to STRING (e.g. ``STRUCT(a INTEGER)``, ``INTEGER[]``) never leak their inner definition
         into ``length``.
 
+        Sub-second timestamp precision is carried in the DuckDB type *name*
+        (``TIMESTAMP_S`` / ``_MS`` / ``_NS``) rather than a ``TIMESTAMP(p)`` modifier, so it is
+        looked up from ``_TIMESTAMP_PRECISION`` and emitted as the Keboola ``length`` -> Storage
+        creates ``TIMESTAMP_NTZ(0/3/9)`` instead of defaulting to ``(9)``.
+
         Note: DuckDB does not retain VARCHAR length internally, so casts like ``VARCHAR(2)``
         arrive here already collapsed to plain ``VARCHAR`` and cannot be recovered.
         """
@@ -253,6 +268,8 @@ class Component(ComponentBase):
         length = None
         if "(" in duckdb_type and base_name in Component._LENGTH_BEARING_TYPES:
             length = duckdb_type[duckdb_type.index("(") + 1 : duckdb_type.rindex(")")].strip()
+        elif base_name in Component._TIMESTAMP_PRECISION:
+            length = Component._TIMESTAMP_PRECISION[base_name]
 
         return BaseType(dtype=dtype, length=length)
 

--- a/tests/unit/test_component_types.py
+++ b/tests/unit/test_component_types.py
@@ -46,15 +46,19 @@ class TestDuckdbTypeToBaseType(unittest.TestCase):
         self._assert("DATE", SupportedDataTypes.DATE, None)
 
     def test_timestamp(self):
+        # Plain TIMESTAMP (microsecond) and TIMESTAMPTZ are deliberately left without an
+        # explicit length so Storage keeps its default width — the common case is unchanged
+        # to avoid a platform-wide precision shift on existing configs.
         self._assert("TIMESTAMP", SupportedDataTypes.TIMESTAMP, None)
         self._assert("TIMESTAMP WITH TIME ZONE", SupportedDataTypes.TIMESTAMP, None)
 
     def test_timestamp_precision_variants(self):
-        # The customer's case: TIMESTAMP_S came out as VARCHAR(16777216) because the
-        # sub-second precision variants were not recognized and fell back to STRING.
-        self._assert("TIMESTAMP_S", SupportedDataTypes.TIMESTAMP, None)
-        self._assert("TIMESTAMP_MS", SupportedDataTypes.TIMESTAMP, None)
-        self._assert("TIMESTAMP_NS", SupportedDataTypes.TIMESTAMP, None)
+        # The customer's case: TIMESTAMP_S must land as TIMESTAMP_NTZ(0), not (9). DuckDB
+        # encodes sub-second precision in the type name, so each variant maps to its Keboola
+        # fractional-seconds precision: _S = second (0), _MS = millisecond (3), _NS = nanosecond (9).
+        self._assert("TIMESTAMP_S", SupportedDataTypes.TIMESTAMP, "0")
+        self._assert("TIMESTAMP_MS", SupportedDataTypes.TIMESTAMP, "3")
+        self._assert("TIMESTAMP_NS", SupportedDataTypes.TIMESTAMP, "9")
 
     def test_complex_type_falls_back_to_string_without_length(self):
         # STRUCT(...) / arrays must not leak their inner definition into `length`.


### PR DESCRIPTION
## Why

Follow-up to #20 on the same support ticket (SUPPORT-16781 / CFTL-713). On retest, a column cast as DuckDB `TIMESTAMP_S` came out in Storage as `TIMESTAMP_NTZ(9)` on a fresh/auto-created output table, when it should be `TIMESTAMP_NTZ(0)` — `TIMESTAMP_S` is second precision with no sub-second component.

**Root cause:** #20 added `TIMESTAMP_S/_MS/_NS` to the `TIMESTAMP` branch of `_map_base_type` so they map to a timestamp type at all (before #20 they fell through to `VARCHAR(16777216)`). But `duckdb_type_to_base_type` only derives `length` from a parenthesized modifier (`DECIMAL(p,s)`, `VARCHAR(n)`). DuckDB encodes sub-second timestamp precision in the type **name**, not a `TIMESTAMP(p)` modifier, so these variants carried no `length` → the manifest omitted it → Storage fell back to its default `(9)`.

## What

- Add `_TIMESTAMP_PRECISION = {TIMESTAMP_S: "0", TIMESTAMP_MS: "3", TIMESTAMP_NS: "9"}` and emit it as the Keboola `length`, so Storage creates `TIMESTAMP_NTZ(0/3/9)` to match the source precision.
- Update the unit test to lock the three variants' precision.

## Backwards compatibility

Deliberately narrow. Only the manifest `length` for the three explicit variants changes; nothing else (no config schema, state, auth, column names/order, PK, or incremental flag):

| DuckDB type | length before → after | Storage type | Change |
|---|---|---|---|
| `TIMESTAMP_S` | none → `0` | `(9)` → `(0)` | narrows (no data loss — second precision has no sub-second part) |
| `TIMESTAMP_MS` | none → `3` | `(9)` → `(3)` | narrows (millisecond source) |
| `TIMESTAMP_NS` | none → `9` | `(9)` → `(9)` | **no-op** (explicit `9` == default) |
| plain `TIMESTAMP` / `TIMESTAMP WITH TIME ZONE` | none → none | unchanged | **untouched by design** — the common case is not shifted |

The only real narrowings are `_S` and `_MS`, both rare explicit-precision types. The only existing typed tables that could see a precision mismatch are ones auto-created since #20 shipped (2026-07-27) — before that these columns were `VARCHAR`, and this PR doesn't touch that transition. Same accepted precision-correction class as #19/#20; those released with no observed failure spike across the component's fleet.

## Testing

- `uv run ruff check .` — clean
- `uv run python -m pytest tests/unit` — all pass, including `test_timestamp_precision_variants` (reproduces the reported `TIMESTAMP_S → (0)` case) and `test_timestamp` (locks plain `TIMESTAMP`/`TIMESTAMPTZ` at no explicit length)
- Functional/datadir suite is Docker-only (version venvs), runs in CI; its expected manifests use only plain `CAST(... AS TIMESTAMP)` and remain valid.

## Not in scope

`VARCHAR(n)` length preservation (DuckDB drops it before export) and a full "map every DuckDB type" pass — separate product decisions tracked on the ticket. The typed-output-table workaround already covers the enforcement need there.

Ticket: CFTL-713 / SUPPORT-16781.
